### PR TITLE
Cherry-pickable branch

### DIFF
--- a/webnative-filecoin/package.json
+++ b/webnative-filecoin/package.json
@@ -10,6 +10,7 @@
   "dependencies": {
     "@glif/filecoin-address": "^1.1.0-beta.18",
     "fp-ts": "^2.9.5",
+    "noble-bls12-381": "^0.9.0",
     "webnative": "^0.21.3"
   }
 }

--- a/webnative-filecoin/src/crypto/bls12-381/operations.ts
+++ b/webnative-filecoin/src/crypto/bls12-381/operations.ts
@@ -1,0 +1,40 @@
+import * as bls from 'noble-bls12-381';
+
+// Filecoin specification on BLS12-381 usage
+// https://spec.filecoin.io/algorithms/crypto/signatures/
+// Filecoin uses G1 for public keys and G2 for signatures
+// https://github.com/paulmillr/noble-bls12-381
+
+
+export type BlsSignature = Uint8Array;
+export type BlsPublicKey = Uint8Array;
+export type BlsPrivateKey = Uint8Array;
+
+export type BlsSigningBytes = Uint8Array;
+export type BlsMessageBytes = Uint8Array;
+
+export const getPublicKey = (privateKey: BlsPrivateKey): BlsPublicKey => {
+  // can return string | Uint8Array as public key;
+  // but we know explicitly that it's always Uint8Array; ts-compiler isnt so smart
+  const pubKeyBytes: Uint8Array | string = bls.getPublicKey(privateKey);
+  // bls.hexToBytes isnt exported, so this doesnt work
+  // return typeof pubKeyBytes === 'string' ? bls.hexToBytes(pubKeyBytes) : pubKeyBytes;
+
+  // TODO: this should be an assertion, but log warning instead. Better constrain type
+  if (pubKeyBytes instanceof Uint8Array) console.warn(
+    'unexpected, pub key should always be uint8Array (err wn_fil_bls_ops_a');
+  return <Uint8Array>pubKeyBytes;
+};
+
+export const blsVerify = async (
+  signature: BlsSignature,
+  signingBytes: BlsSigningBytes,
+  publicKey: BlsPublicKey): Promise<boolean>  => {
+  return bls.verify(signature, signingBytes, publicKey);
+};
+
+export const blsSign = async (
+  signingBytes: BlsSigningBytes,
+  privateKey: BlsPrivateKey): Promise<BlsSignature> => {
+  return bls.sign(signingBytes, privateKey);
+};

--- a/webnative-filecoin/src/crypto/bls12-381/types.ts
+++ b/webnative-filecoin/src/crypto/bls12-381/types.ts
@@ -1,2 +1,0 @@
-export type BlsPublicKey = Uint8Array;
-export type BlsPrivateKey = Uint8Array;

--- a/webnative-filecoin/src/ucan/permissions.ts
+++ b/webnative-filecoin/src/ucan/permissions.ts
@@ -1,10 +1,37 @@
 import * as ucanPermissions from 'webnative/ucan/permissions';
 
-export type Permissions =
-  ucanPermissions.Permissions &
-  {
-    keychain?: KeychainPermissions;
-  };
+const KeychainWnfsDirectory: string = "Keychain";
 
-export type KeychainPermissions = {
-  keychainPaths: string[];};
+// TODO: don't yet extend the permissions object; rather write the
+//       keys as an additional privatePaths
+// export type Permissions =
+//   ucanPermissions.Permissions &
+//   {
+//     keychain?: KeychainPermissions;
+//   };
+
+// export type KeychainPermissions = {
+//   keychainPaths: string[];};
+
+
+export const requestKeychainPermissions = (
+  nameParam: string,
+  creatorParam: string,
+  privatePathsParam: string[],
+  publicPathsParam: string[]
+): ucanPermissions.Permissions => {
+  // add "floofs/private/Keychain/creator/name" as a private FS resource
+  const keychainPath = KeychainWnfsDirectory.concat(
+    creatorParam + '/' + nameParam);
+  privatePathsParam.push(keychainPath);
+  return {
+    app: {
+      name: nameParam,
+      creator: creatorParam
+    },
+    fs: {
+      privatePaths: privatePathsParam,
+      publicPaths: publicPathsParam
+    }
+  }
+}

--- a/webnative-filecoin/yarn.lock
+++ b/webnative-filecoin/yarn.lock
@@ -564,6 +564,11 @@ native-fetch@^2.0.1:
   dependencies:
     globalthis "^1.0.1"
 
+noble-bls12-381@^0.9.0:
+  version "0.9.0"
+  resolved "https://registry.yarnpkg.com/noble-bls12-381/-/noble-bls12-381-0.9.0.tgz#1da93c208708963acf594d5d892c561182371e15"
+  integrity sha512-D04HbbvdxcLkRlcl1GAGk1vu0Hoe2ZtfadaFfL6CqW4mFV890magfIh0duzmb9yaB2BH21e+KmZc5HXjQe9sQw==
+
 node-addon-api@^2.0.0:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/node-addon-api/-/node-addon-api-2.0.2.tgz#432cfa82962ce494b132e9d72a15b29f71ff5d32"


### PR DESCRIPTION
@dholms super excited to have you join on the SDK in #4. I want to stay out of your way, so I thought Id collect some commits on a branch here in the periphery of where you re working

the commit message hopefully explain a bit, but

a. `requestKeychainPermissions`. Initially I had put an extended permissions object to add a `keychain?:string`, but with the better `wnfil.initialise(fs:FileSystem)` function; instead users can call `wn.initialise( { permissions: requestKeychainPermissions(name, creator, privatePaths, publicPaths) }`

b. as discussed last Friday, we can move the library functions into the SDK. First one the BLS wrapper.