### PR TITLE
Add social footer and fix mobile header

### DIFF
--- a/src/components/Footer.svelte
+++ b/src/components/Footer.svelte
@@ -1,0 +1,48 @@
+<script>
+  import { Grid, Row, Column, Link, Icon } from 'carbon-components-svelte';
+  import LogoSlack32 from 'carbon-icons-svelte/lib/LogoSlack32';
+  import GameConsole32 from 'carbon-icons-svelte/lib/GameConsole32';
+  import LogoGithub32 from 'carbon-icons-svelte/lib/LogoGithub32';
+  import Chat32 from 'carbon-icons-svelte/lib/Chat32';
+</script>
+
+<footer class="bx--content">
+  <Grid>
+    <Row>
+      <Column>
+        <div class="social-icons">
+          <Link href="https://filecoin.io/slack/" target="_blank">
+            <Icon render={LogoSlack32} style="fill: var(--cds-icon-01)" />
+          </Link>
+          <Link href="https://discord.gg/daDMAjE" target="_blank">
+            <Icon render={GameConsole32} style="fill: var(--cds-icon-01)" />
+          </Link>
+          <Link
+            href="https://github.com/fission-suite/filecoin-backup"
+            target="_blank"
+          >
+            <Icon render={LogoGithub32} style="fill: var(--cds-icon-01)" />
+          </Link>
+          <Link href="https://talk.fission.codes/tag/filecoin" target="_blank">
+            <Icon render={Chat32} style="fill: var(--cds-icon-01)" />
+          </Link>
+        </div>
+      </Column>
+    </Row>
+  </Grid>
+</footer>
+
+<style>
+  footer {
+    grid-row-start: 2;
+    grid-row-end: 3;
+    background: var(--cds-ui-01);
+  }
+
+  .social-icons {
+    display: grid;
+    grid-template-columns: 1fr 1fr 1fr 1fr;
+    column-gap: 1rem;
+    place-items: center center;
+  }
+</style>

--- a/src/components/Header.svelte
+++ b/src/components/Header.svelte
@@ -62,11 +62,11 @@
   {#if session.authed}
     <HeaderUtilities>
       <div class="indicators">
-        <div class="indicator">
+        <div class="fission-indicator">
           <img class="logo" src="/icon.png" alt="Fission username" />
           <span>{session.username}</span>
         </div>
-        <div class="indicator">
+        <div class="filecoin-indicator">
           <img
             class="logo"
             src="/filecoin-logo.svg"
@@ -74,7 +74,7 @@
           />
           <span>10.0 FIL</span>
         </div>
-        <div class="indicator">
+        <div class="filecoin-indicator">
           <img
             class="logo"
             src="/filecoin-symbol-color.svg"
@@ -96,14 +96,16 @@
     padding: 0 1rem;
   }
 
-  .indicator {
+  .fission-indicator,
+  .filecoin-indicator {
     display: grid;
     place-items: center left;
     grid-template-columns: auto 1fr;
     column-gap: 0.5rem;
   }
 
-  .indicator > span {
+  .fission-indicator > span,
+  .filecoin-indicator > span {
     color: #ffffff;
   }
 
@@ -111,5 +113,15 @@
     display: inline-block;
     width: 1.5rem;
     height: 1.5rem;
+  }
+
+  @media (max-width: 671px) {
+    .indicators {
+      grid-template-columns: 1fr;
+    }
+
+    .filecoin-indicator {
+      display: none;
+    }
   }
 </style>

--- a/src/routes/_layout.svelte
+++ b/src/routes/_layout.svelte
@@ -50,6 +50,7 @@
         <slot />
       </Grid>
     </Content>
+    <Footer />
   </Theme>
 </div>
 

--- a/src/routes/_layout.svelte
+++ b/src/routes/_layout.svelte
@@ -3,6 +3,7 @@
   import { Content, Grid } from 'carbon-components-svelte';
   import Header from '../components/Header.svelte';
   import Theme from '../components/Theme.svelte';
+  import Footer from '../components/Footer.svelte';
   import SvelteSeo from 'svelte-seo';
 
   let theme: 'g10' = 'g10';
@@ -41,11 +42,21 @@
   }}
 />
 
-<Theme persist bind:theme>
-  <Header />
-  <Content style="background: none; padding: 1rem; height: calc(100vh - 4rem)">
-    <Grid style="height: 100%">
-      <slot />
-    </Grid>
-  </Content>
-</Theme>
+<div id="layout">
+  <Theme persist bind:theme>
+    <Header />
+    <Content style="background: none; padding: 1rem;">
+      <Grid style="height: 100%">
+        <slot />
+      </Grid>
+    </Content>
+  </Theme>
+</div>
+
+<style>
+  #layout {
+    height: 100vh;
+    display: grid;
+    grid-template-rows: 1fr auto;
+  }
+</style>

--- a/src/routes/index.svelte
+++ b/src/routes/index.svelte
@@ -143,7 +143,7 @@
   .error {
     display: grid;
     place-items: center center;
-    height: 100%;
+    height: calc(100vh - 4rem);
   }
 
   .welcome {


### PR DESCRIPTION
## Summary

This PR fixes/implements the following **bugs/features**

* [x] Adds a footer with social icons
* [x]  Fixes header indicators on mobile

The social icons link to the Fisison and Filecoin communities to encourage users to get involved, read more, or submit issues to the project.

The header was overcrowded when we showed the Fission auth indicator, wallet balance, and Lotus provider balance on mobile. The change here makes it so that only the Fission auth indicator is shown on small devices.

## Test plan (required)

On desktop

![desktop](https://user-images.githubusercontent.com/7957636/109194125-f7e37c00-774d-11eb-8473-f13724c83511.png)

On mobile

![mobile](https://user-images.githubusercontent.com/7957636/109194144-003bb700-774e-11eb-9bbc-bb8d19c3efac.png)

## After Merge
* [ ] Does this change invalidate any docs or tutorials? _If so ensure the changes needed are either made or recorded_
* [ ] Does this change require a release to be made? Is so please create and deploy the release

