### PR TITLE
Add send method and message IDs

### DIFF
--- a/webnative-filecoin/src/index.ts
+++ b/webnative-filecoin/src/index.ts
@@ -12,7 +12,8 @@ export const getWallet = async (fs: FileSystem): Promise<Wallet> => {
     to: providerAddress,
     amount: 0,
     time: Date.now(),
-    blockheight: 31330
+    blockheight: 31330,
+    messageId: 'bafy2bzacedrpgf23kp34snrlkzl6c8ch4n12gtg3pbpzjjl2wmyszdl6ljyr1'
   }
   const receipts = [
     {
@@ -25,6 +26,6 @@ export const getWallet = async (fs: FileSystem): Promise<Wallet> => {
       amount: 2.2,
       time: 1613413741000
     }
-  ] 
+  ]
   return new Wallet({ privKey, address, providerAddress, balance, providerBalance, receipts })
 }

--- a/webnative-filecoin/src/wallet/index.ts
+++ b/webnative-filecoin/src/wallet/index.ts
@@ -76,18 +76,8 @@ export default class Wallet {
     if (amount > this.balance) {
       throw new Error("Insufficient funds")
     }
-    this.balance -= amount
     this.providerBalance += amount
-    const receipt = {
-      from: this.address,
-      to: this.providerAddress,
-      amount: amount,
-      time: Date.now(),
-      blockheight: 311330,
-      messageId: 'bafy2bzacedrpgf23kp34snrlkzl6c8ch4n12gtg3pbpzjjl2wmyszdl6ljyr1'
-    }
-    this.receipts.push(receipt)
-    return receipt
+    return await this.send(this.providerAddress, amount)
   }
 
   async send(to: Address, amount: number): Promise<Receipt> {

--- a/webnative-filecoin/src/wallet/index.ts
+++ b/webnative-filecoin/src/wallet/index.ts
@@ -24,6 +24,7 @@ export type Receipt = {
   amount: number
   time: number
   blockheight: number
+  messageId: string
 }
 
 export type Address = string
@@ -71,8 +72,8 @@ export default class Wallet {
     return this.providerBalance
   }
 
-  async fundProvider(amount: number):  Promise<Receipt> {
-    if(amount > this.balance) {
+  async fundProvider(amount: number): Promise<Receipt> {
+    if (amount > this.balance) {
       throw new Error("Insufficient funds")
     }
     this.balance -= amount
@@ -82,10 +83,11 @@ export default class Wallet {
       to: this.providerAddress,
       amount: amount,
       time: Date.now(),
-      blockheight: 311330
+      blockheight: 311330,
+      messageId: 'bafy2bzacedrpgf23kp34snrlkzl6c8ch4n12gtg3pbpzjjl2wmyszdl6ljyr1'
     }
     this.receipts.push(receipt)
-    return receipt 
+    return receipt
   }
 
   async getPrevReceipts(): Promise<Receipt[]> {

--- a/webnative-filecoin/src/wallet/index.ts
+++ b/webnative-filecoin/src/wallet/index.ts
@@ -90,6 +90,23 @@ export default class Wallet {
     return receipt
   }
 
+  async send(to: Address, amount: number): Promise<Receipt> {
+    if (amount > this.balance) {
+      throw new Error("Insufficient funds")
+    }
+    this.balance -= amount
+    const receipt = {
+      from: this.address,
+      to: to,
+      amount: amount,
+      time: Date.now(),
+      blockheight: 311331,
+      messageId: 'bafy2bdacedrpgf23kp34snrlkzl6c8ch4n12gtg3pbpzjjl1wmyszdl8ljyr1'
+    }
+    this.receipts.push(receipt)
+    return receipt
+  }
+
   async getPrevReceipts(): Promise<Receipt[]> {
     return this.receipts
   }


### PR DESCRIPTION
## Summary

This PR fixes/implements the following **bugs/features**

* [x] Adds a `messgeId` to receipts
* [x] Adds a `send` method to wallets

Explain the **motivation** for making this change. What existing problem does the pull request solve?

The message IDs will be used to generate links for users to view transactions in a block explorer. The `send` method will be used to send FIL to an arbitrary address.

## Test plan (required)

Calling `await wallet.send('test', 1)` on an instantiated wallet returns:

```
{
    "from": "t3q5cgdg2b6uzazz7sbkdjqoafxzvuagbawh76wamwazupvvwzol7glitxs4e2j2wd5ncsg2mltrdt2t6gdisa",
    "to": "test",
    "amount": 1,
    "time": 1615417201250,
    "blockheight": 311331,
    "messageId": "bafy2bdacedrpgf23kp34snrlkzl6c8ch4n12gtg3pbpzjjl1wmyszdl8ljyr1"
}
```
## After Merge
* [ ] Does this change invalidate any docs or tutorials? _If so ensure the changes needed are either made or recorded_
* [ ] Does this change require a release to be made? Is so please create and deploy the release

