### PR TITLE
Update discourse feed and link to forum

### DIFF
--- a/src/components/Footer.svelte
+++ b/src/components/Footer.svelte
@@ -23,7 +23,10 @@
           >
             <Icon render={LogoGithub32} style="fill: var(--cds-icon-01)" />
           </Link>
-          <Link href="https://talk.fission.codes/tag/filecoin" target="_blank">
+          <Link
+            href="https://talk.fission.codes/c/projects/webnative-filecoin-integration/48"
+            target="_blank"
+          >
             <Icon render={Chat32} style="fill: var(--cds-icon-01)" />
           </Link>
         </div>

--- a/src/feed.ts
+++ b/src/feed.ts
@@ -2,7 +2,7 @@
 export type Post = { title: string, url: string }
 
 export async function getPosts(): Promise<Post[]> {
-  const res = await fetch('https://talk.fission.codes/tag/filecoin.json');
+  const res = await fetch('https://talk.fission.codes/c/projects/webnative-filecoin-integration/48.json');
   const json: any = await res.json();
 
   if (res.ok) {
@@ -16,7 +16,7 @@ export async function getPosts(): Promise<Post[]> {
       });
     });
 
-    return posts.slice(0, 10);
+    return posts.slice(0, 6).reverse();
   } else {
     throw new Error('Could not load most recent posts');
   }


### PR DESCRIPTION
## Summary

This PR fixes/implements the following **bugs/features**

* [x] Reverse the order of posts to show oldest at top and limit to six most recent
* [x] Pull posts from the `webnative-filecoin-integration` project instead of `filecoin`
tag
* [x] Update Discourse forum footer link

We want to reverse the order of posts and link to and pull from the project instead of the tag.

## Test plan (required)

![updated-feed](https://user-images.githubusercontent.com/7957636/113213503-219c3100-922d-11eb-9ad6-fd26d5749b76.png)

## After Merge
* [ ] Does this change invalidate any docs or tutorials? _If so ensure the changes needed are either made or recorded_
* [ ] Does this change require a release to be made? Is so please create and deploy the release

